### PR TITLE
chg: Add links to AV in README.md !minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # SDCM
 Standard Dynamic Combat Mission
+
+## Builds
+
+The latest MIZ files build can be obtained from [Appveyor](https://ci.appveyor.com/project/132ndNeck/sdcm/build/artifacts).
+
+The whole build history can be found [here](https://ci.appveyor.com/project/132ndNeck/sdcm/history).


### PR DESCRIPTION
I added links to the latest MIZ builds on Appveyor, so people landing on the repository page can find the MIZ file.